### PR TITLE
Add updateTopGG to the "Bot List Updater" to update bot stats on top.gg

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -119,6 +119,9 @@ client.on('ready', async () => {
 		setInterval(async () => {
 			updater.updateBotsXyz(await this.guildCount())
 		}, 600000);
+		setInterval(async () => {
+			updater.updateTopGG(await this.guildCount(), await this.shardCount())
+		}, 600000);
 
 		// Interval for updating the amount of servers the bot is used on on discordbotlist.com every 5 minutes
 		// setInterval(async () => {
@@ -199,8 +202,15 @@ exports.guildCount = async () => {
 /**
  * Counting all clusters.
  * */
-exports.clusterCount = async () => {
+exports.clusterCount = () => {
 	return client.cluster.count;
+}
+
+/**
+ * Counting all shards.
+ * */
+exports.shardCount = () => {
+	return client.shard.count;
 }
 
 /**

--- a/cluster.js
+++ b/cluster.js
@@ -1,6 +1,5 @@
 // Startup file
 const Cluster = require('discord-hybrid-sharding')
-const { AutoPoster } = require('topgg-autoposter')
 require('dotenv').config()
 
 // Manager
@@ -9,11 +8,6 @@ const manager = new Cluster.Manager('./bot.js', { totalShards: 'auto', token: pr
 // Logger
 const Util = require('./modules/util')
 const Logger = new Util.Logger()
-
-// eslint-disable-next-line no-unused-vars
-if (process.env.NODE_ENV === 'production') {
-	AutoPoster(process.env.TOPGG_TOKEN, manager)
-}
 
 // Spawning
 manager.on('clusterCreate', cluster => Logger.info(`Launched Cluster ${cluster.id}!`))

--- a/commands/info.js
+++ b/commands/info.js
@@ -34,7 +34,7 @@ module.exports = {
 					},
 					{
 						name: 'Clusters',
-						value: await bot.clusterCount(),
+						value: bot.clusterCount(),
 						inline: true,
 					},
 					{

--- a/modules/bot-list-updater.js
+++ b/modules/bot-list-updater.js
@@ -3,6 +3,7 @@ const config = {
 	BOT_ID: process.env.BOT_ID,
 	ONDISCORDXYZ_TOKEN: process.env.ONDISCORDXYZ_TOKEN,
 	DISCORDBOTLIST_TOKEN: process.env.DISCORDBOTLIST_TOKEN,
+	TOPGG_TOKEN: process.env.TOPGG_TOKEN,
 }
 const got = require('got')
 const Util = require('./util')
@@ -11,6 +12,36 @@ const Logger = new Util.Logger()
 exports.BotListUpdater = class {
 	constructor(shardId) {
 		this.shardId = shardId;
+	}
+
+	/**
+	 * Updates the numbers on top.gg
+	 *
+	 * @param {Number} guildSize - Amount of guilds where the server is on.
+	 * @param {Number} shards - Amount of shards
+	 *
+	 * */
+	updateTopGG(guildSize, shards) {
+		got.post(`https://top.gg/api/bots/${config.BOT_ID}/stats`, {
+			json: {
+				server_count: guildSize,
+				shard_count: shards,
+			},
+			headers: {
+				Authorization: config.TOPGG_TOKEN.toString(),
+			},
+			responseType: 'json',
+		}).then(res => {
+			if (res.statusCode !== 204) {
+				Logger.error('Error occurred when trying to update the server amount on top.gg! Code: ' + res.statusCode)
+				console.error(res)
+			}
+			else {
+				Logger.info('Updated guild amount on top.gg')
+			}
+		}).catch(e => {
+			console.log(e)
+		})
 	}
 
 	/**
@@ -26,7 +57,7 @@ exports.BotListUpdater = class {
 					guildCount: guildSize,
 				},
 				headers: {
-					Authorization: config.ONDISCORDXYZ_TOKEN.toString()
+					Authorization: config.ONDISCORDXYZ_TOKEN.toString(),
 				},
 				responseType: 'json',
 			}).then(res => {


### PR DESCRIPTION
This PR adds a new POST request to the API of top.gg to update the stats of the bot (again).
It also removes `AutoPoster` because of the usage of `discord-hybrid-sharding`

**Type of change:**

- [x] This PR includes major improvements. (like a new feature or module)
- [x] The features or fixes made in this PR were tested.
